### PR TITLE
feat: add first tests for the HTTP endpoints

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -1,0 +1,13 @@
+package app
+
+import "github.com/gin-gonic/gin"
+
+func SetupRouter() *gin.Engine {
+	router := gin.Default()
+
+	router.GET("/", Root)
+	router.GET("/ratings", Ratings)
+	router.POST("/ratings", AddRating)
+
+	return router
+}

--- a/main.go
+++ b/main.go
@@ -1,18 +1,13 @@
 package main
 
 import (
-	"github.com/gin-gonic/gin"
 	"github.com/testcontainers/workshop-go/internal/app"
 )
 
 func main() {
-	router := gin.Default()
+	router := app.SetupRouter()
 
 	router.LoadHTMLGlob("templates/*.tmpl")
-
-	router.GET("/", app.Root)
-	router.GET("/ratings", app.Ratings)
-	router.POST("/ratings", app.AddRating)
 
 	router.Run(":8080")
 }

--- a/step-1-getting-started.md
+++ b/step-1-getting-started.md
@@ -67,10 +67,9 @@ go get github.com/stretchr/testify
 This might be helpful if the internet connection at the workshop venue is somewhat slow.
 
 ```text
-docker pull postgres:14-alpine
+docker pull postgres:15.3-alpine
 docker pull redis:6-alpine
-docker pull openjdk:8-jre-alpine
-docker pull confluentinc/cp-kafka:6.2.1
+docker pull docker.redpanda.com/redpandadata/redpanda:v23.1.7
 ```
 
 ### 

--- a/step-8-integration-tests-for-api.md
+++ b/step-8-integration-tests-for-api.md
@@ -1,0 +1,78 @@
+# Step 8: Integration tests for the API
+
+In this step you will add integration tests for the API, and for that we are going to use the [`net/httptest`](https://pkg.go.dev/net/http/httptest) package from the standard library.
+
+## The `net/httptest` package
+
+The `net/httptest` package provides a set of utilities for HTTP testing. It includes a test server that implements the `http.Handler` interface, a global `Client` to make requests to test servers, and various functions to parse HTTP responses.
+
+For the specific use case of `Gin`, we are going to follow its [official documentation](https://gin-gonic.com/docs/testing/).
+
+## Testing the HTTP endpoints
+
+For that, we are going to create a new file called `router_test.go` inside the `internal/app` package. Please add the following content:
+
+```go
+package app_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/workshop-go/internal/app"
+)
+
+func TestRootRoute(t *testing.T) {
+	router := app.SetupRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// the metadata is empty because we do not have real dependencies started
+	assert.Equal(t, `{"metadata":{"Ratings":"","Streams":"","Talks":""}}`, w.Body.String())
+}
+
+func TestRoutesFailBecauseDependenciesAreNotStarted(t *testing.T) {
+	router := app.SetupRouter()
+
+	t.Run("GET /ratings fails", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/ratings?talkId=testcontainers-integration-testing", nil)
+		require.NoError(t, err)
+		router.ServeHTTP(w, req)
+
+		// we are receiving a 500 because the ratings repository is not started
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("POST /ratings", func(t *testing.T) {
+		body := []byte(`{"talkId":"testcontainers-integration-testing","value":5}`)
+
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("POST", "/ratings", bytes.NewReader(body))
+		require.NoError(t, err)
+		router.ServeHTTP(w, req)
+
+		// we are receiving a 500 because the ratings repository is not started
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+}
+
+```
+
+Let's check what we are doing here. For the first test method, `TestRootRoute`, we are doing the following:
+
+- We are creating a new `httptest.Recorder` to record the response.
+- We are creating a new `http.Request` with the `GET` method and the `/` path.
+- We are calling the `ServeHTTP` method on the router with the `httptest.Recorder` and the `http.Request`.
+- We are asserting that the response code is `200`.
+- We are asserting that the response body is `{"metadata":{"Ratings":"","Streams":"","Talks":""}}`. The values of the connection strings are empty because we do not have any dependency started.
+
+The second test method, `TestRoutesFailBecauseDependenciesAreNotStarted`, is verifying that the routes that depend on the repositories are failing with a `500 Internal Server error` response code. That's because the runtime dependencies are not started for this test.


### PR DESCRIPTION
## What does this PR do?

It uses net/httptest for adding tests for the endpoints.

The /ratings endpoint will fail with a 500 code because the backend services are not present

