### PR TITLE
fix: makefile in localstack tutorial

### DIFF
--- a/step-7-adding-localstack.md
+++ b/step-7-adding-localstack.md
@@ -113,7 +113,8 @@ mod-tidy:
 	go mod tidy
 
 build-lambda: mod-tidy
-	GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -o bootstrap main.go
+	# If you are using Testcontainers Cloud, please add 'GOARCH=amd64' in order to get the localstack's lambdas using the right architecture
+	GOOS=linux go build -tags lambda.norpc -o bootstrap main.go
 
 zip-lambda: build-lambda
 	zip -j function.zip bootstrap

--- a/step-7-adding-localstack.md
+++ b/step-7-adding-localstack.md
@@ -113,7 +113,7 @@ mod-tidy:
 	go mod tidy
 
 build-lambda: mod-tidy
-	GOOS=linux go build -tags lambda.norpc -o bootstrap main.go
+	GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -o bootstrap main.go
 
 zip-lambda: build-lambda
 	zip -j function.zip bootstrap


### PR DESCRIPTION
The Makefile in the [localstack.md](https://github.com/testcontainers/workshop-go/blob/main/step-7-adding-localstack.md) is missing `GOARCH=amd64`.